### PR TITLE
Stop verifying API key before every call, make SendAsync calls library-friendly

### DIFF
--- a/Rosier.Akismet.Net/Akismet.cs
+++ b/Rosier.Akismet.Net/Akismet.cs
@@ -73,14 +73,8 @@ namespace Rosier.Akismet.Net
         /// <returns>
         ///   <c>Spam</c> when the comment is spam, <c>Ham</c> when the comment is Ham aor <c>Invalid</c> when an error occured.
         /// </returns>
-        /// <exception cref="System.ArgumentException"> when the API key is not validated.</exception>
         public async Task<CommentCheck> CheckCommentAsync(AkismetComment comment)
         {
-            if (!this.keyVerified)
-            {
-                throw new ArgumentException("The API key is not verified. Call first the VerifyKey method.");
-            }
-
             var keyvalues = comment.CreateKeyValues();
             var client = this.CreateClient(true);
             var request = new HttpRequestMessage(HttpMethod.Post, AkismetUrls.ValidateComment);
@@ -111,11 +105,6 @@ namespace Rosier.Akismet.Net
         /// <returns></returns>
         public async Task<bool> SubmitSpamAsync(AkismetComment comment)
         {
-            if (!this.keyVerified)
-            {
-                throw new ArgumentException("The API key is not verified. Call first the VerifyKey method.");
-            }
-
             var keyvalues = comment.CreateKeyValues();
             var client = this.CreateClient(true);
             var request = new HttpRequestMessage(HttpMethod.Post, AkismetUrls.SubmitSpam);
@@ -138,14 +127,8 @@ namespace Rosier.Akismet.Net
         /// </summary>
         /// <param name="comment">The comment.</param>
         /// <returns></returns>
-        /// <exception cref="System.NotImplementedException"></exception>
         public async Task<bool> SubmitHamAsync(AkismetComment comment)
         {
-            if (!this.keyVerified)
-            {
-                throw new ArgumentException("The API key is not verified. Call first the VerifyKey method.");
-            }
-
             var keyvalues = comment.CreateKeyValues();
             var client = this.CreateClient(true);
             var request = new HttpRequestMessage(HttpMethod.Post, AkismetUrls.SubmitHam);

--- a/Rosier.Akismet.Net/Akismet.cs
+++ b/Rosier.Akismet.Net/Akismet.cs
@@ -51,7 +51,7 @@ namespace Rosier.Akismet.Net
             var request = new HttpRequestMessage(HttpMethod.Post, AkismetUrls.VerifyKey);
             request.Content = new FormUrlEncodedContent(keyValues);
 
-            var response = await client.SendAsync(request);
+            var response = await client.SendAsync(request).ConfigureAwait(false);
             if (response.StatusCode == System.Net.HttpStatusCode.OK)
             {
                 var responseString = await response.Content.ReadAsStringAsync();
@@ -121,7 +121,7 @@ namespace Rosier.Akismet.Net
             var request = new HttpRequestMessage(HttpMethod.Post, AkismetUrls.SubmitSpam);
             request.Content = new FormUrlEncodedContent(keyvalues);
 
-            var response = await client.SendAsync(request);
+            var response = await client.SendAsync(request).ConfigureAwait(false);
             if (response.StatusCode == System.Net.HttpStatusCode.OK)
             {
                 var responseString = await response.Content.ReadAsStringAsync();


### PR DESCRIPTION
Akismet told me directly that I shouldn't be verifying the API key more than once, so I removed those extra API calls from the library. Also, I had to add Task.ConfigureAwait() to the HttpClient.SendAsync calls before this code worked without deadlocking in a library. 